### PR TITLE
Fixing major CMakeLists.txt mistake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,16 +31,19 @@ set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
     TYPE OPTIONAL
     PURPOSE "Required to use KStyle convenience functionalities in style")
 
+option(FOR_FLATPAK "Build Lightly for Flatpak" OFF)
 option(WITH_DECORATIONS "Build Lightly window decorations for KWin" ON)
 if(WITH_DECORATIONS)
     find_package(KDecoration2 REQUIRED)
     add_subdirectory(kdecoration)
 endif()
 
-add_subdirectory(colors)
 add_subdirectory(liblightlycommon)
 add_subdirectory(kstyle)
-add_subdirectory(misc)
+if (!FOR_FLATPAK)
+    add_subdirectory(colors)
+    add_subdirectory(misc)
+endif()
 
 include(ECMSetupVersion)
 ecm_setup_version(${PROJECT_VERSION} VARIABLE_PREFIX LIGHTLY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,12 @@ configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/LightlyConfig.cmake.i
 file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.cpp *.h)
 kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})
 
+if (!FOR_FLATPAK)
 install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/LightlyConfig.cmake"
                "${CMAKE_CURRENT_BINARY_DIR}/LightlyConfigVersion.cmake"
         DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
         COMPONENT Devel
 )
+endif()
 
 feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -130,14 +130,18 @@ if(LIGHTLY_HAVE_KWAYLAND)
     target_link_libraries(lightly Plasma::KWaylandClient)
 endif()
 
-
+if (FOR_FLATPAK)
+    set(LIB_TARGET ${QT_PLUGINS_DIR}/styles/)
+else()
+    set(LIB_TARGET ${KDE_INSTALL_QTPLUGINDIR}/kstyle/themes)
+endif()
 ########### install files ###############
-install(TARGETS lightly DESTINATION ${KDE_INSTALL_QTPLUGINDIR}/styles/)
-install(FILES lightly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
-
+install(TARGETS lightly DESTINATION ${LIB_TARGET})
+if (!FOR_FLATPAK)
+    install(FILES lightly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
+endif()
 ########### subdirectories ###############
 
 if(!FOR_FLATPAK)
     add_subdirectory(config)
 endif()
-

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 if (FOR_FLATPAK)
     set(LIB_TARGET ${QT_PLUGINS_DIR}/styles/)
 else()
-    set(LIB_TARGET ${KDE_INSTALL_QTPLUGINDIR}/kstyle/themes)
+    set(LIB_TARGET ${KDE_INSTALL_QTPLUGINDIR}/styles/)
 endif()
 ########### install files ###############
 install(TARGETS lightly DESTINATION ${LIB_TARGET})

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -136,4 +136,8 @@ install(TARGETS lightly DESTINATION ${KDE_INSTALL_QTPLUGINDIR}/styles/)
 install(FILES lightly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
 
 ########### subdirectories ###############
-add_subdirectory(config)
+
+if(!FOR_FLATPAK)
+    add_subdirectory(config)
+endif()
+

--- a/org.kde.KStyle.Lightly.json
+++ b/org.kde.KStyle.Lightly.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.KStyle.Lightly",
-    "branch": "6.8",
+    "branch": "6.9",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "6.8",
+    "runtime-version": "6.9",
     "appstream-compose": false,
     "separate-locales": false,
     "modules": [

--- a/org.kde.KStyle.Lightly.json
+++ b/org.kde.KStyle.Lightly.json
@@ -1,0 +1,25 @@
+{
+    "id": "org.kde.KStyle.Lightly",
+    "branch": "6.8",
+    "runtime": "org.kde.Platform",
+    "build-extension": true,
+    "sdk": "org.kde.Sdk",
+    "runtime-version": "6.8",
+    "appstream-compose": false,
+    "separate-locales": false,
+    "modules": [
+            {
+                "name": "Lightly",
+                "buildsystem": "cmake",
+                "builddir": true,
+                "config-opts": ["-DQT_PLUGINS_DIR=/usr/share/runtime/lib/plugins/Lightly", "-DCMAKE_INSTALL_PREFIX=/usr/share/runtime/lib/plugins/Lightly",
+                                "-DUSE_QT6=ON", "-DWITH_DECORATIONS=OFF", "-DFOR_FLATPAK=ON"],
+                "sources": [
+                    {
+                        "type": "dir",
+                        "path": "."
+                    }
+                ]
+            }
+        ]
+}


### PR DESCRIPTION
In my PR with flatpak support I didn't pay much attention to system install destination, which I accidentally set to `${KDE_INSTALL_DATADIR}/kstyle/themes` instead of `${KDE_INSTALL_QTPLUGINDIR}/styles/`, so this PR is to fix that mistake.